### PR TITLE
Toggle Chat Swipe off when swiper is moving

### DIFF
--- a/packages/app/index.js
+++ b/packages/app/index.js
@@ -1,6 +1,8 @@
 import 'react-native-gesture-handler';
 import './globals';
 import '@ethersproject/shims';
+import { YellowBox } from 'react-native';
+import _ from 'lodash';
 
 import { AppRegistry } from 'react-native';
 
@@ -8,3 +10,11 @@ import { name as appName } from './app.json';
 import { Providers } from './src/Providers';
 
 AppRegistry.registerComponent(appName, () => Providers);
+
+YellowBox.ignoreWarnings(['Setting a timer']);
+const _console = _.clone(console);
+console.warn = (message) => {
+    if (message.indexOf('Setting a timer') <= -1) {
+        _console.warn(message);
+    }
+};

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -8,7 +8,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { graphql, useMutation, useQuery } from 'relay-hooks';
 
 import { AppQuery } from './__generated__/AppQuery.graphql';
-import { LiveTabs, MainTabs} from './Navigator';
+import { LiveTabs, MainTabs } from './Navigator';
 import { useBurner } from './hooks/Burner';
 import { GetOrCreateUser } from './contexts/Web3Context/mutations/GetOrCreateUserMutation';
 import { Web3Context } from './contexts';
@@ -92,6 +92,7 @@ export const App = (): ReactElement => {
     const [metaProvider, setMetaProvider] = useState<providers.JsonRpcSigner>();
     const [skip, setSkip] = useState(true);
     const [walletScroll, setWalletScroll] = useState(true);
+    const [chatScroll, setChatScroll] = useState(true);
     const [index, setIndex] = React.useState(1);
     const { props, retry, error, cached } = useQuery<AppQuery>(
         graphql`
@@ -148,6 +149,10 @@ export const App = (): ReactElement => {
     useEffect(() => {
         burner && setupUserSession();
     }, [burner]);
+    useEffect(() => {
+        console.log('Wallet Scroll: ' + walletScroll);
+        console.log('Chat Scroll: ' + chatScroll);
+    });
 
     const handleIndex = (i: number) => {
         setIndex(i);
@@ -180,6 +185,8 @@ export const App = (): ReactElement => {
             index={1}
             scrollEnabled={walletScroll}
             directionalLockEnabled
+            onScroll={() => setChatScroll(false)}
+            onMomentumScrollEnd={() => setChatScroll(true)}
         >
             <WalletDropdown
                 me={me}
@@ -203,7 +210,11 @@ export const App = (): ReactElement => {
             </NavigationContainer>
             {index === 1 && (
                 <NavigationContainer>
-                    <LiveTabs me={me} liveChallenge={liveChallenge} />
+                    <LiveTabs
+                        me={me}
+                        liveChallenge={liveChallenge}
+                        chatScroll={chatScroll}
+                    />
                 </NavigationContainer>
             )}
         </Swiper>

--- a/packages/app/src/Navigator.tsx
+++ b/packages/app/src/Navigator.tsx
@@ -30,7 +30,7 @@ export type MainTabsParams = {
     Market: Record<string, unknown>;
 };
 
-export type LiveTabProps = {
+export type LiveProps = {
     mainnetProvider: providers.InfuraProvider;
     localProvider: providers.JsonRpcProvider | providers.InfuraProvider;
     injectedProvider: providers.JsonRpcProvider | null;
@@ -53,18 +53,11 @@ export type LiveDashboardProps = StackScreenProps<
     ProfileStackParams,
     'LiveDashboard'
 >;
-export type LiveTabsParams = {
-    Comments: AppQueryResponse;
-    Lineup: AppQueryResponse;
+
+export type ChatProps = AppQueryResponse & {
+    chatScroll: boolean;
 };
-export type CommentsTabProps = MaterialTopTabScreenProps<
-    LiveTabsParams,
-    'Comments'
->;
-export type LineupTabProps = MaterialTopTabScreenProps<
-    LiveTabsParams,
-    'Lineup'
->;
+export type LineupProps = AppQueryResponse;
 
 const ProfileStackNavigator = createStackNavigator<ProfileStackParams>();
 
@@ -102,28 +95,40 @@ export function ProfileStack({
     );
 }
 
-const LiveTabsNavigator = createMaterialTopTabNavigator<LiveTabsParams>();
+export function LiveTabs({ liveChallenge, me, chatScroll }: any): ReactElement {
+    const [index, setIndex] = React.useState(1);
 
-export function LiveTabs({
-    liveChallenge,
-    me
-}: LiveTabsParams['Comments'] & LiveTabsParams['Lineup']): ReactElement {
+    const [routes] = React.useState<Route[]>([
+        { key: 'vote', title: 'Vote' },
+        { key: 'chat', title: 'Chat' },
+
+        { key: 'lineup', title: 'Lineup' }
+    ]);
+
+    const renderScene = ({ route }: { route: Route }) => {
+        switch (route.key) {
+            case 'vote':
+                return <></>;
+            case 'chat':
+                return (
+                    <Comments
+                        liveChallenge={liveChallenge}
+                        me={me}
+                        chatScroll={chatScroll}
+                    />
+                );
+            case 'lineup':
+                return <Lineup me={me} />;
+            default:
+                return null;
+        }
+    };
     return (
-        <LiveTabsNavigator.Navigator initialRouteName="Comments">
-            <LiveTabsNavigator.Screen
-                name="Comments"
-                component={Comments}
-                initialParams={{
-                    liveChallenge,
-                    me
-                }}
-            />
-            <LiveTabsNavigator.Screen
-                name="Lineup"
-                component={Lineup}
-                initialParams={{ me }}
-            />
-        </LiveTabsNavigator.Navigator>
+        <TabView
+            navigationState={{ index, routes }}
+            renderScene={renderScene}
+            onIndexChange={setIndex}
+        />
     );
 }
 

--- a/packages/app/src/components/Live/Live.tsx
+++ b/packages/app/src/components/Live/Live.tsx
@@ -1,23 +1,16 @@
 import React, {
-    useEffect,
     useRef,
-    useState,
-    useContext,
-    useCallback,
     ReactElement
 } from 'react';
-import { Button, Text, View } from 'react-native';
+import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { graphql, useFragment } from 'relay-hooks';
-import { Web3Context } from '../../contexts';
 import Video from 'react-native-video';
 
-import { LiveTabProps, LiveTabs } from '../../Navigator';
-import { Address, Balance } from '../Web3';
-import { Live_me$key, Live_me } from './__generated__/Live_me.graphql';
-import { WalletDropdown } from '../../WalletDropdown';
+import { LiveProps} from '../../Navigator';
+import { Live_me$key} from './__generated__/Live_me.graphql';
 
-type Props = LiveTabProps;
+type Props = LiveProps;
 
 export const Live = ({
     mainnetProvider,

--- a/packages/app/src/components/comment/CommentList.tsx
+++ b/packages/app/src/components/comment/CommentList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Blockies from '../Web3/Blockie';
 
 import { graphql } from 'react-relay';
@@ -21,6 +21,7 @@ import {
 
 type Props = {
     query: CommentList_query$key;
+    chatScroll: boolean;
 };
 
 const commentsFragmentSpec = graphql`
@@ -152,6 +153,7 @@ export const CommentList = (props: Props): React.ReactElement => {
             refreshing={isFetchingTop}
             ItemSeparatorComponent={() => <View style={null} />}
             ListFooterComponent={null}
+            scrollEnabled={props.chatScroll}
         />
     );
 };

--- a/packages/app/src/components/comment/Comments.tsx
+++ b/packages/app/src/components/comment/Comments.tsx
@@ -5,7 +5,7 @@ import { graphql, useFragment, useQuery } from 'relay-hooks';
 import { CommentsQuery } from './__generated__/CommentsQuery.graphql';
 import { CommentList } from './CommentList';
 import { CreateCommentComposer } from './CreateCommentComposer';
-import { CommentsTabProps as Props } from '../../Navigator';
+import { ChatProps as Props } from '../../Navigator';
 import { Comments_me$key } from './__generated__/Comments_me.graphql';
 import { useCommentAddedSubscription } from '../../hooks/useCommentAddedSubscription';
 import {
@@ -36,7 +36,7 @@ export const Comments = (props: Props): React.ReactElement => {
                 ...CreateCommentComposer_liveChallenge
             }
         `,
-        props.route.params.liveChallenge as Comments_liveChallenge$key
+        props.liveChallenge as Comments_liveChallenge$key
     );
 
     const me = useFragment(
@@ -45,14 +45,18 @@ export const Comments = (props: Props): React.ReactElement => {
                 ...CreateCommentComposer_me
             }
         `,
-        props.route.params.me as Comments_me$key
+        props.me as Comments_me$key
     );
 
     useCommentAddedSubscription();
 
     return data ? (
         <View style={styles.background}>
-            <CommentList query={data} />
+            <CommentList
+                query={data}
+                chatScroll={props.chatScroll}
+                setWalletScroll={props.setWalletScroll}
+            />
             <CreateCommentComposer me={me} liveChallenge={liveChallenge} />
         </View>
     ) : (

--- a/packages/app/src/components/lineup/Lineup.tsx
+++ b/packages/app/src/components/lineup/Lineup.tsx
@@ -4,7 +4,7 @@ import { graphql, useQuery } from 'relay-hooks';
 
 import { LineupQuery } from './__generated__/LineupQuery.graphql';
 import { LineupList } from './LineupList';
-import { LineupTabProps as Props } from '../../Navigator';
+import { LineupProps as Props } from '../../Navigator';
 
 const styles = StyleSheet.create({
     background: { backgroundColor: '#e6ffff', height: '100%' }

--- a/packages/app/src/contexts/Web3Context/Web3Context.tsx
+++ b/packages/app/src/contexts/Web3Context/Web3Context.tsx
@@ -23,7 +23,6 @@ export const Web3ContextProvider: React.FC = ({ children }) => {
 
     const connectDID = async (connector: IConnector, wallet: Wallet) => {
         const token = await did.createToken(connector, wallet);
-        console.log('token: ', token);
         await AsyncStorage.setItem('token', token);
 
         // commitLocalUpdate(env, store => {


### PR DESCRIPTION
Toggled chat swipe gestures off when swiper is moving

To do this I had to replace the material top navigator with the `react-native-tab-view`. React native tab view is the same as the previous integration however it allows us access to the swipe event data. The entire app has now switched to using react-native-tab-view and will only use react navigation for the stack navigators