### PR TITLE
Live styles overlay

### DIFF
--- a/packages/app/src/components/Live/Header.tsx
+++ b/packages/app/src/components/Live/Header.tsx
@@ -12,6 +12,7 @@ type Props = {
     setIsPaused: (b: boolean) => void;
     setIsMuted: (b: boolean) => void;
     animationEvent: boolean;
+    overlayVisible: boolean;
     afterAnimationOut: () => void;
 };
 
@@ -23,6 +24,7 @@ export const Header = ({
     isMuted,
     setIsMuted,
     animationEvent,
+    overlayVisible,
     afterAnimationOut
 }: Props): ReactElement => {
     const [animation, setAnimation] = useState(false);
@@ -36,7 +38,12 @@ export const Header = ({
     };
 
     return (
-        <Fade event={animationEvent} afterAnimationOut={afterAnimationOut} down>
+        <Fade
+            event={animationEvent}
+            afterAnimationOut={afterAnimationOut}
+            down
+            pointerEvents={overlayVisible ? 'box-none' : 'none'}
+        >
             <View style={styles.container}>
                 <View style={styles.header}>
                     <View style={styles.infoContainer}>

--- a/packages/app/src/components/Live/Live.tsx
+++ b/packages/app/src/components/Live/Live.tsx
@@ -46,13 +46,15 @@ export const Live = (props: Props): ReactElement => {
         props.liveChallenge
     );
 
-    const [overlayVisible, setOverlayVisible] = useState(false);
-    const [animation, setAnimation] = useState(false);
+    const [overlayVisible, setOverlayVisible] = useState(true);
+    const [animation, setAnimation] = useState(true);
     const sheetRef = useRef<BottomSheetType | null>(null);
 
     const handlePress = () => {
         setAnimation(!animation);
-        if (!overlayVisible) {
+        if (animation) {
+            setOverlayVisible(false);
+        } else {
             setOverlayVisible(true);
         }
     };
@@ -67,31 +69,26 @@ export const Live = (props: Props): ReactElement => {
                     onPress={handlePress}
                     style={styles.absolute}
                 />
-                {overlayVisible && (
-                    <>
-                        <Header
-                            isMuted={props.isMuted}
-                            setIsMuted={props.setIsMuted}
-                            isPaused={props.isPaused}
-                            setIsPaused={props.setIsPaused}
-                            animationEvent={animation}
-                            image={me.addresses[0]}
-                            title={liveChallenge.title}
-                            afterAnimationOut={() => setOverlayVisible(false)}
-                        />
-
-                        <LiveChat
-                            animationEvent={animation}
-                            commentsQuery={props.commentsQuery}
-                            image={me.addresses[0]}
-                            setBottomSheetVisible={() =>
-                                sheetRef.current?.expand()
-                            }
-                            me={me}
-                            liveChallenge={liveChallenge}
-                        />
-                    </>
-                )}
+                <Header
+                    overlayVisible={overlayVisible}
+                    isMuted={props.isMuted}
+                    setIsMuted={props.setIsMuted}
+                    isPaused={props.isPaused}
+                    setIsPaused={props.setIsPaused}
+                    animationEvent={animation}
+                    image={me.addresses[0]}
+                    title={liveChallenge.title}
+                    afterAnimationOut={() => setOverlayVisible(false)}
+                />
+                <LiveChat
+                    overlayVisible={overlayVisible}
+                    animationEvent={animation}
+                    commentsQuery={props.commentsQuery}
+                    image={me.addresses[0]}
+                    setBottomSheetVisible={() => sheetRef.current?.expand()}
+                    me={me}
+                    liveChallenge={liveChallenge}
+                />
             </View>
             {/* )} */}
             <BottomSheet ref={sheetRef}>

--- a/packages/app/src/components/Live/LiveChat.tsx
+++ b/packages/app/src/components/Live/LiveChat.tsx
@@ -27,6 +27,7 @@ import { Buttons } from './Buttons';
 type Props = {
     commentsQuery: LiveChatList_query$key;
     animationEvent: boolean;
+    overlayVisible: boolean;
     image: string;
 };
 
@@ -36,7 +37,8 @@ export const LiveChat = ({
     animationEvent,
     image,
     setBottomSheetVisible,
-    me
+    me,
+    overlayVisible
 }: Props): ReactElement => {
     const [inputVisible, setInputVisible] = useState(false);
     const [animation, setAnimation] = useState(false);
@@ -80,51 +82,61 @@ export const LiveChat = ({
         <KeyboardAvoidingView
             behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
             keyboardVerticalOffset={48}
+            pointerEvents={overlayVisible ? 'box-none' : 'none'}
         >
-            <Fade event={animationEvent} up>
+            <Fade event={animationEvent} up pointerEvents="box-none">
                 <LinearGradient
                     colors={['#00000000', 'black']}
                     style={{ overflow: 'visible' }}
+                    pointerEvents="box-none"
                 >
-                    <View style={styles.container}>
-                        <Animated.View style={animatedStyle}>
+                    <Animated.View style={animatedStyle} pointerEvents="auto">
+                        <View style={styles.container}>
                             <View style={styles.messagesContainer}>
                                 <LiveChatList query={commentsQuery} />
                                 {!inputVisible && (
                                     <Plus onPress={handlePress} />
                                 )}
                             </View>
-                        </Animated.View>
 
-                        <View
-                            onLayout={(event) =>
-                                setInputHeight(event.nativeEvent.layout.height)
-                            }
-                            style={{
-                                zIndex: inputVisible ? 1 : -3,
-                                paddingTop: '4%'
-                            }}
-                        >
-                            <Fade
-                                duration={400}
-                                event={animation}
-                                afterAnimationOut={() => setInputVisible(false)}
+                            <View
+                                onLayout={(event) =>
+                                    setInputHeight(
+                                        event.nativeEvent.layout.height
+                                    )
+                                }
+                                style={{
+                                    zIndex: inputVisible ? 1 : -3,
+                                    paddingTop: '4%'
+                                }}
                             >
-                                <Buttons
-                                    onPredictLeft={() => console.log('predict')}
-                                    onDonate={() => setBottomSheetVisible(true)}
-                                    onPredictRight={() =>
-                                        console.log('predict')
+                                <Fade
+                                    duration={400}
+                                    event={animation}
+                                    afterAnimationOut={() =>
+                                        setInputVisible(false)
                                     }
-                                />
-                                <LiveChatComposer
-                                    image={image}
-                                    liveChallenge={liveChallenge}
-                                    me={me}
-                                />
-                            </Fade>
+                                >
+                                    <Buttons
+                                        onPredictLeft={() =>
+                                            console.log('predict')
+                                        }
+                                        onDonate={() =>
+                                            setBottomSheetVisible(true)
+                                        }
+                                        onPredictRight={() =>
+                                            console.log('predict')
+                                        }
+                                    />
+                                    <LiveChatComposer
+                                        image={image}
+                                        liveChallenge={liveChallenge}
+                                        me={me}
+                                    />
+                                </Fade>
+                            </View>
                         </View>
-                    </View>
+                    </Animated.View>
                 </LinearGradient>
             </Fade>
         </KeyboardAvoidingView>

--- a/packages/app/src/components/Live/LiveChat.tsx
+++ b/packages/app/src/components/Live/LiveChat.tsx
@@ -14,7 +14,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import LinearGradient from 'react-native-linear-gradient';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import { colors } from '../UI';
+import { colors, RoundButton } from '../UI';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { LiveChatList } from '../comment/LiveChatList';
 import { LiveChatList_query$key } from '../comment/__generated__/LiveChatList_query.graphql';
@@ -25,6 +25,7 @@ import { LiveChatComposer_me$key } from './__generated__/LiveChatComposer_me.gra
 import { Buttons } from './Buttons';
 
 type Props = {
+    setBottomSheetVisible: (b: boolean) => void;
     commentsQuery: LiveChatList_query$key;
     animationEvent: boolean;
     overlayVisible: boolean;
@@ -84,59 +85,66 @@ export const LiveChat = ({
             keyboardVerticalOffset={48}
             pointerEvents={overlayVisible ? 'box-none' : 'none'}
         >
-            <Fade event={animationEvent} up pointerEvents="box-none">
+            <Fade
+                event={animationEvent}
+                up
+                pointerEvents="box-none"
+                afterAnimationOut={() => {
+                    setInputVisible(false);
+                    setAnimation(false);
+                }}
+            >
                 <LinearGradient
                     colors={['#00000000', 'black']}
                     style={{ overflow: 'visible' }}
                     pointerEvents="box-none"
                 >
-                    <Animated.View style={animatedStyle} pointerEvents="auto">
-                        <View style={styles.container}>
+                    <View style={styles.container} pointerEvents="box-none">
+                        <Animated.View
+                            style={animatedStyle}
+                            pointerEvents="auto"
+                        >
                             <View style={styles.messagesContainer}>
                                 <LiveChatList query={commentsQuery} />
                                 {!inputVisible && (
-                                    <Plus onPress={handlePress} />
+                                    <RoundButton
+                                        onPress={handlePress}
+                                        icon="plus"
+                                        style={{ width: 46, height: 46 }}
+                                    />
                                 )}
                             </View>
+                        </Animated.View>
 
-                            <View
-                                onLayout={(event) =>
-                                    setInputHeight(
-                                        event.nativeEvent.layout.height
-                                    )
-                                }
-                                style={{
-                                    zIndex: inputVisible ? 1 : -3,
-                                    paddingTop: '4%'
-                                }}
+                        <View
+                            onLayout={(event) =>
+                                setInputHeight(event.nativeEvent.layout.height)
+                            }
+                            style={{
+                                zIndex: inputVisible ? 1 : -3,
+                                paddingTop: '4%'
+                            }}
+                        >
+                            <Fade
+                                duration={400}
+                                event={animation}
+                                afterAnimationOut={() => setInputVisible(false)}
                             >
-                                <Fade
-                                    duration={400}
-                                    event={animation}
-                                    afterAnimationOut={() =>
-                                        setInputVisible(false)
+                                <Buttons
+                                    onPredictLeft={() => console.log('predict')}
+                                    onDonate={() => setBottomSheetVisible(true)}
+                                    onPredictRight={() =>
+                                        console.log('predict')
                                     }
-                                >
-                                    <Buttons
-                                        onPredictLeft={() =>
-                                            console.log('predict')
-                                        }
-                                        onDonate={() =>
-                                            setBottomSheetVisible(true)
-                                        }
-                                        onPredictRight={() =>
-                                            console.log('predict')
-                                        }
-                                    />
-                                    <LiveChatComposer
-                                        image={image}
-                                        liveChallenge={liveChallenge}
-                                        me={me}
-                                    />
-                                </Fade>
-                            </View>
+                                />
+                                <LiveChatComposer
+                                    image={image}
+                                    liveChallenge={liveChallenge}
+                                    me={me}
+                                />
+                            </Fade>
                         </View>
-                    </Animated.View>
+                    </View>
                 </LinearGradient>
             </Fade>
         </KeyboardAvoidingView>
@@ -192,23 +200,3 @@ const styles = StyleSheet.create({
         marginRight: 12
     }
 });
-
-const Plus = ({ onPress }) => (
-    <TouchableOpacity style={styles.plusIcon} onPress={onPress}>
-        <Icon name="plus" size={40} color="white" />
-    </TouchableOpacity>
-);
-
-const Cash = () => (
-    <View style={styles.cashBg}>
-        <View style={styles.cashBgInner}>
-            <Icon name="currency-usd" size={22} color={colors.pink} />
-        </View>
-    </View>
-);
-
-const Donation = () => (
-    <View style={styles.donation}>
-        <Text style={styles.donationText}>$5.00</Text>
-    </View>
-);

--- a/packages/app/src/components/Live/LiveChatComposer.tsx
+++ b/packages/app/src/components/Live/LiveChatComposer.tsx
@@ -13,6 +13,7 @@ import {
 } from '../comment/mutations/CreateCommentMutation';
 import { LiveChatComposer_liveChallenge$key } from './__generated__/LiveChatComposer_liveChallenge.graphql';
 import { LiveChatComposer_me$key } from './__generated__/LiveChatComposer_me.graphql';
+import { colors, RoundButton } from '../UI';
 
 type Props = {
     image: string;
@@ -87,21 +88,14 @@ export const LiveChatComposer = (props: Props) => {
                 multiline={true}
                 numberOfLines={1}
             />
-            <TouchableOpacity
-                style={styles.submit}
+            <RoundButton
                 disabled={!(content.length > 0)}
                 onPress={handleCreateComment}
-            >
-                <Icon
-                    name="send"
-                    size={24}
-                    color="white"
-                    style={{
-                        marginRight: -3,
-                        opacity: content.length > 0 ? 1 : 0.4
-                    }}
-                />
-            </TouchableOpacity>
+                icon="send"
+                iconSize={32}
+                style={{ width: 46, height: 46 }}
+                iconStyle={{ marginRight: -4 }}
+            />
         </View>
     );
 };

--- a/packages/app/src/components/UI/Fade.tsx
+++ b/packages/app/src/components/UI/Fade.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, ReactNode, useEffect } from 'react';
+import { ViewProps } from 'react-native';
 import Animated, {
     useSharedValue,
     useAnimatedStyle,
@@ -7,7 +8,7 @@ import Animated, {
     runOnJS
 } from 'react-native-reanimated';
 
-interface Props {
+type Props = ViewProps & {
     children: ReactNode;
     event: boolean;
     up?: boolean;
@@ -16,7 +17,7 @@ interface Props {
     duration?: number;
     distance?: number;
     style?: any;
-}
+};
 
 const Fade = ({
     children,
@@ -26,7 +27,8 @@ const Fade = ({
     distance = 10,
     down,
     up,
-    style
+    style,
+    ...rest
 }: Props): ReactElement => {
     const startPosition = !up && !down ? 0 : down ? distance * -1 : distance;
     const moveAnimation = useSharedValue(startPosition);
@@ -72,7 +74,9 @@ const Fade = ({
     });
 
     return (
-        <Animated.View style={[animatedStyle, style]}>{children}</Animated.View>
+        <Animated.View style={[animatedStyle, style]} {...rest}>
+            {children}
+        </Animated.View>
     );
 };
 


### PR DESCRIPTION
Adds pink buttons to live chat. Start with live overlay on. Replaces chat component toggle with opacity and pointerEvents so the chat component doesn't need to reload when the overlay is toggled. Closes #248 

![live-styles-overlay](https://user-images.githubusercontent.com/19338130/122123959-de913900-cdeb-11eb-8ba9-0af11f33bbfd.gif)
