### PR TITLE
New challenge buttons

### DIFF
--- a/packages/app/src/Navigator.tsx
+++ b/packages/app/src/Navigator.tsx
@@ -100,7 +100,8 @@ export function ProfileStack({
         <ProfileStackNavigator.Navigator
             initialRouteName="Profile"
             screenOptions={{
-                headerShown: false
+                headerShown: false,
+                gestureEnabled: false
             }}
         >
             <ProfileStackNavigator.Screen

--- a/packages/app/src/components/UI/Button.tsx
+++ b/packages/app/src/components/UI/Button.tsx
@@ -3,10 +3,10 @@ import {
     Text,
     StyleSheet,
     TouchableOpacityProps,
-    TextStyle
+    TextStyle,
+    TouchableOpacity
 } from 'react-native';
 import { colors, sizes } from './';
-import { TouchableOpacity } from 'react-native-gesture-handler';
 
 type Props = TouchableOpacityProps & {
     color?: 'orange' | 'gray';

--- a/packages/app/src/components/UI/Title.tsx
+++ b/packages/app/src/components/UI/Title.tsx
@@ -3,7 +3,7 @@ import { Text, StyleSheet, TextStyle } from 'react-native';
 import { sizes } from './';
 
 type Props = {
-    children: string;
+    children: string | string[];
     size?: number;
     shadow?: boolean;
     style?: TextStyle | TextStyle[];

--- a/packages/app/src/components/challenges/Buttons.tsx
+++ b/packages/app/src/components/challenges/Buttons.tsx
@@ -1,0 +1,66 @@
+import React, { ReactElement } from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { Button, colors } from '../UI';
+
+type Props = {};
+
+export const Buttons = ({
+    index,
+    setIndex,
+    nextDisabled
+}: Props): ReactElement => {
+    return (
+        <View style={styles.buttonContainer}>
+            {index > 0 ? (
+                <TouchableOpacity
+                    style={styles.button}
+                    onPress={() => setIndex(index - 1)}
+                >
+                    <Icon
+                        name="chevron-left"
+                        size={56}
+                        color={colors.pink}
+                        style={styles.icon}
+                    />
+                    <Text style={styles.buttonText}>Back</Text>
+                </TouchableOpacity>
+            ) : (
+                <Text></Text>
+            )}
+
+            <TouchableOpacity
+                disabled={nextDisabled}
+                style={styles.button}
+                onPress={() => setIndex(index + 1)}
+            >
+                <Icon
+                    name="chevron-right"
+                    size={56}
+                    color={nextDisabled ? colors.gray : colors.pink}
+                    style={styles.icon}
+                />
+                <Text style={styles.buttonText}>Next</Text>
+            </TouchableOpacity>
+
+            {/* <Button title="Create" onPress={() => console.log('confirm')} /> */}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    buttonContainer: {
+        flexDirection: 'row',
+        justifyContent: 'space-between'
+    },
+    button: {
+        alignItems: 'center'
+    },
+    icon: {
+        marginBottom: -10
+    },
+    buttonText: {
+        color: colors.grayMedium
+    }
+});

--- a/packages/app/src/components/challenges/Buttons.tsx
+++ b/packages/app/src/components/challenges/Buttons.tsx
@@ -1,16 +1,38 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { Button, colors } from '../UI';
+import { FormType } from './CreateChallengeScreen';
 
-type Props = {};
+type Props = {
+    index: number;
+    setIndex: (n: number) => void;
+    form: FormType;
+};
 
-export const Buttons = ({
-    index,
-    setIndex,
-    nextDisabled
-}: Props): ReactElement => {
+export const Buttons = ({ index, setIndex, form }: Props): ReactElement => {
+    const [nextDisabled, setNextDisabled] = useState(true);
+
+    useEffect(() => {
+        if (index === 0) {
+            if (!!form.title && !!form.content && !!form.image) {
+                return setNextDisabled(false);
+            }
+        }
+
+        if (index === 1) {
+            if (
+                form.positiveOptions.length > 0 &&
+                form.positiveOptions.length > 0
+            ) {
+                return setNextDisabled(false);
+            }
+        }
+
+        setNextDisabled(true);
+    }, [form, index]);
+
     return (
         <View style={styles.buttonContainer}>
             {index > 0 ? (
@@ -30,21 +52,23 @@ export const Buttons = ({
                 <Text></Text>
             )}
 
-            <TouchableOpacity
-                disabled={nextDisabled}
-                style={styles.button}
-                onPress={() => setIndex(index + 1)}
-            >
-                <Icon
-                    name="chevron-right"
-                    size={56}
-                    color={nextDisabled ? colors.gray : colors.pink}
-                    style={styles.icon}
-                />
-                <Text style={styles.buttonText}>Next</Text>
-            </TouchableOpacity>
-
-            {/* <Button title="Create" onPress={() => console.log('confirm')} /> */}
+            {index !== 2 ? (
+                <TouchableOpacity
+                    disabled={nextDisabled}
+                    style={styles.button}
+                    onPress={() => setIndex(index + 1)}
+                >
+                    <Icon
+                        name="chevron-right"
+                        size={56}
+                        color={nextDisabled ? colors.gray : colors.pink}
+                        style={styles.icon}
+                    />
+                    <Text style={styles.buttonText}>Next</Text>
+                </TouchableOpacity>
+            ) : (
+                <Button title="Create" onPress={() => console.log('confirm')} />
+            )}
         </View>
     );
 };
@@ -52,7 +76,8 @@ export const Buttons = ({
 const styles = StyleSheet.create({
     buttonContainer: {
         flexDirection: 'row',
-        justifyContent: 'space-between'
+        justifyContent: 'space-between',
+        alignItems: 'center'
     },
     button: {
         alignItems: 'center'

--- a/packages/app/src/components/challenges/CreateChallengeScreen.tsx
+++ b/packages/app/src/components/challenges/CreateChallengeScreen.tsx
@@ -7,7 +7,7 @@ import { Outcomes } from './Outcomes';
 import { Confirm } from './Confirm';
 import { colors, Gradient, Title } from '../UI';
 import { Buttons } from './Buttons';
-import { TabNavSwipeContext } from '../../contexts';
+import { TabNavSwipeContext, SwiperContext } from '../../contexts';
 
 export type FormType = {
     address: string;
@@ -32,11 +32,16 @@ export const CreateChallengeScreen = (props): ReactElement => {
     });
     const { top: paddingTop } = useSafeAreaInsets();
     const { setMainTabsSwipe } = useContext(TabNavSwipeContext);
+    const { setWalletScroll } = useContext(SwiperContext);
 
-    useEffect(() => setMainTabsSwipe(false));
+    useEffect(() => {
+        setMainTabsSwipe(false);
+        setWalletScroll(false);
+    });
 
     const handleBackButton = () => {
         setMainTabsSwipe(true);
+        setWalletScroll(true);
         props.navigation.goBack();
     };
 

--- a/packages/app/src/components/challenges/CreateChallengeScreen.tsx
+++ b/packages/app/src/components/challenges/CreateChallengeScreen.tsx
@@ -22,13 +22,13 @@ export type FormType = {
 export const CreateChallengeScreen = (props): ReactElement => {
     const [index, setIndex] = useState(0);
     const [form, setForm] = useState<FormType>({
-        address: '',
-        title: '',
+        address: 'd',
+        title: 'd',
         // category: '',
-        content: '',
-        positiveOptions: [],
-        negativeOptions: [],
-        image: ''
+        content: 'd',
+        positiveOptions: ['d'],
+        negativeOptions: ['df'],
+        image: 'd'
     });
     const { top: paddingTop } = useSafeAreaInsets();
     const { setMainTabsSwipe } = useContext(TabNavSwipeContext);
@@ -42,13 +42,7 @@ export const CreateChallengeScreen = (props): ReactElement => {
 
     const components = [
         <StartChallenge form={form} setForm={setForm} />,
-        <Outcomes
-            index={index}
-            setIndex={setIndex}
-            form={form}
-            setForm={setForm}
-            type={'negative'}
-        />,
+        <Outcomes form={form} setForm={setForm} />,
         <Confirm index={index} setIndex={setIndex} />
     ];
 
@@ -109,6 +103,7 @@ const styles = StyleSheet.create({
     },
     background: {
         flex: 1,
+        justifyContent: 'space-between',
         padding: '4%',
         borderColor: 'rgba(251, 250, 250, 0.7)',
         borderWidth: 1,

--- a/packages/app/src/components/challenges/CreateChallengeScreen.tsx
+++ b/packages/app/src/components/challenges/CreateChallengeScreen.tsx
@@ -1,12 +1,11 @@
 import React, { ReactElement, useState } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StartChallenge } from './StartChallenge';
-import { ChallengeDescription } from './ChallengeDescription';
 import { Outcomes } from './Outcomes';
 import { Confirm } from './Confirm';
-import { Button, colors, Gradient, Title } from '../UI';
+import { colors, Gradient, Title } from '../UI';
 import { Buttons } from './Buttons';
 
 export type FormType = {
@@ -21,7 +20,6 @@ export type FormType = {
 
 export const CreateChallengeScreen = (props): ReactElement => {
     const [index, setIndex] = useState(0);
-    const [nextButtonEnabled, setNextButtonEnabled] = useState(false);
     const [form, setForm] = useState<FormType>({
         address: '',
         title: '',
@@ -34,25 +32,7 @@ export const CreateChallengeScreen = (props): ReactElement => {
     const { top: paddingTop } = useSafeAreaInsets();
 
     const components = [
-        <StartChallenge
-            form={form}
-            setForm={setForm}
-            index={index}
-            setIndex={setIndex}
-        />,
-        <ChallengeDescription
-            index={index}
-            setIndex={setIndex}
-            form={form}
-            setForm={setForm}
-        />,
-        <Outcomes
-            index={index}
-            setIndex={setIndex}
-            form={form}
-            setForm={setForm}
-            type={'positive'}
-        />,
+        <StartChallenge form={form} setForm={setForm} />,
         <Outcomes
             index={index}
             setIndex={setIndex}
@@ -66,10 +46,30 @@ export const CreateChallengeScreen = (props): ReactElement => {
     return (
         <Gradient>
             <View style={[styles.container, { paddingTop }]}>
-                <Title style={styles.title}>
-                    {form.title && index > 0 ? form.title : 'New Challenge'}
-                </Title>
-                <View style={styles.background}>{components[index]}</View>
+                <View>
+                    <Title style={styles.title}>
+                        {form.title && index > 0 ? form.title : 'New Challenge'}
+                    </Title>
+
+                    {index === 0 && (
+                        <TouchableOpacity
+                            style={styles.backButton}
+                            onPress={() => props.navigation.goBack()}
+                        >
+                            <Icon
+                                name="chevron-left"
+                                size={42}
+                                color={colors.pink}
+                                style={styles.icon}
+                            />
+                        </TouchableOpacity>
+                    )}
+                </View>
+
+                <View style={styles.background}>
+                    {components[index]}
+                    <Buttons index={index} setIndex={setIndex} form={form} />
+                </View>
             </View>
         </Gradient>
     );
@@ -79,6 +79,20 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         paddingHorizontal: '4%'
+    },
+    backButton: {
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        zIndex: 9
+    },
+    icon: {
+        textShadowColor: 'rgba(0,0,0,.3)',
+        textShadowOffset: {
+            width: 0,
+            height: 3
+        },
+        textShadowRadius: 5
     },
     title: {
         textAlign: 'center',

--- a/packages/app/src/components/challenges/CreateChallengeScreen.tsx
+++ b/packages/app/src/components/challenges/CreateChallengeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -7,6 +7,7 @@ import { Outcomes } from './Outcomes';
 import { Confirm } from './Confirm';
 import { colors, Gradient, Title } from '../UI';
 import { Buttons } from './Buttons';
+import { TabNavSwipeContext } from '../../contexts';
 
 export type FormType = {
     address: string;
@@ -30,6 +31,14 @@ export const CreateChallengeScreen = (props): ReactElement => {
         image: ''
     });
     const { top: paddingTop } = useSafeAreaInsets();
+    const { setMainTabsSwipe } = useContext(TabNavSwipeContext);
+
+    useEffect(() => setMainTabsSwipe(false));
+
+    const handleBackButton = () => {
+        setMainTabsSwipe(true);
+        props.navigation.goBack();
+    };
 
     const components = [
         <StartChallenge form={form} setForm={setForm} />,
@@ -54,7 +63,7 @@ export const CreateChallengeScreen = (props): ReactElement => {
                     {index === 0 && (
                         <TouchableOpacity
                             style={styles.backButton}
-                            onPress={() => props.navigation.goBack()}
+                            onPress={handleBackButton}
                         >
                             <Icon
                                 name="chevron-left"

--- a/packages/app/src/components/challenges/CreateChallengeScreen.tsx
+++ b/packages/app/src/components/challenges/CreateChallengeScreen.tsx
@@ -2,12 +2,14 @@ import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { ProfileProps } from '../../Navigator';
 import { StartChallenge } from './StartChallenge';
 import { Outcomes } from './Outcomes';
 import { Confirm } from './Confirm';
 import { colors, Gradient, Title } from '../UI';
 import { Buttons } from './Buttons';
 import { TabNavSwipeContext, SwiperContext } from '../../contexts';
+import { ScrollView } from 'react-native-gesture-handler';
 
 export type FormType = {
     address: string;
@@ -17,18 +19,20 @@ export type FormType = {
     positiveOptions: string[];
     negativeOptions: string[];
     image: string;
+    [key: string]: any;
 };
+type Props = ProfileProps;
 
-export const CreateChallengeScreen = (props): ReactElement => {
+export const CreateChallengeScreen = (props: Props): ReactElement => {
     const [index, setIndex] = useState(0);
     const [form, setForm] = useState<FormType>({
-        address: 'd',
-        title: 'd',
+        address: '',
+        title: '',
         // category: '',
-        content: 'd',
-        positiveOptions: ['d'],
-        negativeOptions: ['df'],
-        image: 'd'
+        content: '',
+        positiveOptions: [],
+        negativeOptions: [],
+        image: ''
     });
     const { top: paddingTop } = useSafeAreaInsets();
     const { setMainTabsSwipe } = useContext(TabNavSwipeContext);
@@ -73,9 +77,14 @@ export const CreateChallengeScreen = (props): ReactElement => {
                         </TouchableOpacity>
                     )}
                 </View>
-
                 <View style={styles.background}>
-                    {components[index]}
+                    <ScrollView
+                        alwaysBounceVertical={false}
+                        showsVerticalScrollIndicator={false}
+                        contentContainerStyle={styles.contentContainer}
+                    >
+                        {components[index]}
+                    </ScrollView>
                     <Buttons index={index} setIndex={setIndex} form={form} />
                 </View>
             </View>
@@ -109,11 +118,16 @@ const styles = StyleSheet.create({
     background: {
         flex: 1,
         justifyContent: 'space-between',
-        padding: '4%',
         borderColor: 'rgba(251, 250, 250, 0.7)',
         borderWidth: 1,
         borderTopLeftRadius: 10,
         borderTopRightRadius: 10,
-        backgroundColor: 'rgba(255, 255, 255, 0.5)'
+        backgroundColor: 'rgba(255, 255, 255, 0.5)',
+        overflow: 'hidden',
+        paddingVertical: '4%'
+    },
+    contentContainer: {
+        paddingHorizontal: '4%',
+        flexGrow: 1
     }
 });

--- a/packages/app/src/components/challenges/CreateChallengeScreen.tsx
+++ b/packages/app/src/components/challenges/CreateChallengeScreen.tsx
@@ -1,12 +1,13 @@
 import React, { ReactElement, useState } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StartChallenge } from './StartChallenge';
 import { ChallengeDescription } from './ChallengeDescription';
 import { Outcomes } from './Outcomes';
 import { Confirm } from './Confirm';
-import { Gradient, Title } from '../UI';
+import { Button, colors, Gradient, Title } from '../UI';
+import { Buttons } from './Buttons';
 
 export type FormType = {
     address: string;
@@ -20,6 +21,7 @@ export type FormType = {
 
 export const CreateChallengeScreen = (props): ReactElement => {
     const [index, setIndex] = useState(0);
+    const [nextButtonEnabled, setNextButtonEnabled] = useState(false);
     const [form, setForm] = useState<FormType>({
         address: '',
         title: '',
@@ -32,7 +34,12 @@ export const CreateChallengeScreen = (props): ReactElement => {
     const { top: paddingTop } = useSafeAreaInsets();
 
     const components = [
-        <StartChallenge form={form} setForm={setForm} />,
+        <StartChallenge
+            form={form}
+            setForm={setForm}
+            index={index}
+            setIndex={setIndex}
+        />,
         <ChallengeDescription
             index={index}
             setIndex={setIndex}
@@ -53,13 +60,7 @@ export const CreateChallengeScreen = (props): ReactElement => {
             setForm={setForm}
             type={'negative'}
         />,
-        <Confirm
-            index={index}
-            setIndex={setIndex}
-            form={form}
-            me={props.route.params.me}
-            jumpTo={props.route.params.jumpTo}
-        />
+        <Confirm index={index} setIndex={setIndex} />
     ];
 
     return (
@@ -68,12 +69,7 @@ export const CreateChallengeScreen = (props): ReactElement => {
                 <Title style={styles.title}>
                     {form.title && index > 0 ? form.title : 'New Challenge'}
                 </Title>
-                <View style={styles.background}>
-                    {components[index]}
-                    <View style={{ height: 60 }}>
-                        {/* buttons placeholder */}
-                    </View>
-                </View>
+                <View style={styles.background}>{components[index]}</View>
             </View>
         </Gradient>
     );

--- a/packages/app/src/components/challenges/OutcomeCard.tsx
+++ b/packages/app/src/components/challenges/OutcomeCard.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useRef, useState } from 'react';
+import React, { ReactElement, useRef, useState, useContext } from 'react';
 import {
     Text,
     View,
@@ -9,13 +9,18 @@ import {
     Platform
 } from 'react-native';
 import { Card, colors, Notch, sizes, Title } from '../UI';
+import Gradient from 'react-native-linear-gradient';
 import { FormType } from './CreateChallengeScreen';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { ScrollView } from 'react-native-gesture-handler';
 
-type Props = {};
+type Props = {
+    type: 'positiveOptions' | 'negativeOptions';
+    form: FormType;
+    setForm: (fn: (f: FormType) => void) => void;
+};
 
-export const OutcomeCard = ({ type, form, setForm }: any): ReactElement => {
+export const OutcomeCard = ({ type, form, setForm }: Props): ReactElement => {
     const [textValue, setTextValue] = useState('');
     const [listHeight, setListHeight] = useState(0);
     const [warningText, setWarningText] = useState('');
@@ -62,6 +67,7 @@ export const OutcomeCard = ({ type, form, setForm }: any): ReactElement => {
             </Title>
             <Card style={styles.card} noPadding>
                 <ScrollView
+                    ref={scrollViewRef}
                     style={styles.outcomeContainer}
                     showsVerticalScrollIndicator={false}
                     contentContainerStyle={{
@@ -77,7 +83,6 @@ export const OutcomeCard = ({ type, form, setForm }: any): ReactElement => {
                         }
                         setListHeight(height);
                     }}
-                    ref={scrollViewRef}
                 >
                     {form[type].map((option) => (
                         <View style={styles.outcome}>
@@ -104,35 +109,38 @@ export const OutcomeCard = ({ type, form, setForm }: any): ReactElement => {
                     ))}
                 </ScrollView>
                 <View style={styles.inputContainer}>
-                    <TouchableOpacity
-                        style={[
-                            styles.addIconBg,
-                            {
-                                backgroundColor: positive
-                                    ? colors.pink
-                                    : colors.gray
+                    <View style={styles.addIconContainer}>
+                        <Gradient
+                            colors={
+                                positive
+                                    ? [colors.pink, colors.pink]
+                                    : [colors.gray, colors.grayDark]
                             }
-                        ]}
-                        onPress={() => addOption(type)}
-                    >
-                        <Icon
-                            name="plus-thick"
-                            size={28}
-                            color="white"
-                            style={styles.addIcon}
+                            style={[styles.addIconGradient]}
+                        >
+                            <TouchableOpacity onPress={() => addOption(type)}>
+                                <Icon
+                                    name="plus-thick"
+                                    size={30}
+                                    color="white"
+                                    style={styles.addIcon}
+                                />
+                            </TouchableOpacity>
+                        </Gradient>
+                    </View>
+                    <View style={styles.inputUnderline}>
+                        <TextInput
+                            onChangeText={setTextValue}
+                            value={textValue}
+                            style={styles.input}
+                            placeholder={
+                                positive
+                                    ? 'e.g. I beat my best record'
+                                    : 'e.g. I don’t finish in time'
+                            }
+                            placeholderTextColor={colors.gray}
                         />
-                    </TouchableOpacity>
-                    <TextInput
-                        onChangeText={setTextValue}
-                        value={textValue}
-                        style={styles.input}
-                        placeholder={
-                            positive
-                                ? 'e.g. I beat my best record'
-                                : 'e.g. I don’t finish in time'
-                        }
-                        placeholderTextColor={colors.gray}
-                    />
+                    </View>
                 </View>
             </Card>
 
@@ -174,20 +182,38 @@ const styles = StyleSheet.create({
         paddingHorizontal: '4%',
         paddingVertical: '2%'
     },
-    addIconBg: {
-        backgroundColor: colors.pink,
-        padding: 2,
+    addIconContainer: {
         borderRadius: 100,
-        marginRight: '4%'
+        zIndex: 9,
+        shadowColor: 'black',
+        shadowOpacity: 0.25,
+        shadowOffset: {
+            width: 0,
+            height: 5
+        },
+        shadowRadius: 5,
+        elevation: 5
     },
-    addIcon: {},
-    input: {
-        flex: 1,
+    addIconGradient: {
+        padding: 2,
+        borderRadius: 100
+    },
+    addIcon: {
+        textShadowColor: 'rgba(0, 0, 0, 0.3)',
+        textShadowOffset: { width: 0, height: 4 },
+        textShadowRadius: 5
+    },
+    inputUnderline: {
         borderBottomColor: colors.gray,
         borderBottomWidth: 1,
+        flex: 1,
+        marginLeft: -10
+    },
+    input: {
         fontSize: 16,
         paddingTop: 0,
-        paddingBottom: 2,
+        paddingBottom: 0,
+        marginLeft: 20,
         color: colors.grayDark
     },
     warning: {

--- a/packages/app/src/components/challenges/OutcomeCard.tsx
+++ b/packages/app/src/components/challenges/OutcomeCard.tsx
@@ -1,12 +1,10 @@
-import React, { ReactElement, useRef, useState, useContext } from 'react';
+import React, { ReactElement, useRef, useState } from 'react';
 import {
     Text,
     View,
     StyleSheet,
     TextInput,
-    TouchableOpacity,
-    KeyboardAvoidingView,
-    Platform
+    TouchableOpacity
 } from 'react-native';
 import { Card, colors, Notch, sizes, Title } from '../UI';
 import Gradient from 'react-native-linear-gradient';
@@ -17,14 +15,14 @@ import { ScrollView } from 'react-native-gesture-handler';
 type Props = {
     type: 'positiveOptions' | 'negativeOptions';
     form: FormType;
-    setForm: (fn: (f: FormType) => void) => void;
+    setForm: (form: FormType | ((prevState: FormType) => FormType)) => void;
 };
 
 export const OutcomeCard = ({ type, form, setForm }: Props): ReactElement => {
     const [textValue, setTextValue] = useState('');
     const [listHeight, setListHeight] = useState(0);
     const [warningText, setWarningText] = useState('');
-    const scrollViewRef = useRef(null);
+    const scrollViewRef = useRef<ScrollView>(null);
     const positive = type === 'positiveOptions';
 
     const addOption = (type: string) => {
@@ -39,7 +37,7 @@ export const OutcomeCard = ({ type, form, setForm }: Props): ReactElement => {
             );
 
         if (!duplicate && textValue.length > 2) {
-            setForm((prevState: FormType) => ({
+            setForm((prevState) => ({
                 ...prevState,
                 [type]: [...prevState[type], textValue]
             }));
@@ -65,6 +63,7 @@ export const OutcomeCard = ({ type, form, setForm }: Props): ReactElement => {
             <Title style={styles.title}>
                 Add {positive ? 'positive' : 'negative'} outcomes
             </Title>
+
             <Card style={styles.card} noPadding>
                 <ScrollView
                     ref={scrollViewRef}
@@ -77,7 +76,7 @@ export const OutcomeCard = ({ type, form, setForm }: Props): ReactElement => {
                     }}
                     onContentSizeChange={(_, height) => {
                         if (height > listHeight) {
-                            scrollViewRef.current.scrollToEnd({
+                            scrollViewRef.current?.scrollToEnd({
                                 animated: true
                             });
                         }
@@ -85,7 +84,7 @@ export const OutcomeCard = ({ type, form, setForm }: Props): ReactElement => {
                     }}
                 >
                     {form[type].map((option) => (
-                        <View style={styles.outcome}>
+                        <View style={styles.outcome} key={option}>
                             <View style={styles.notchContainer}>
                                 <Notch
                                     title={option}
@@ -102,12 +101,12 @@ export const OutcomeCard = ({ type, form, setForm }: Props): ReactElement => {
                                     name="close-thick"
                                     size={22}
                                     color={colors.pink}
-                                    style={styles.editIcon}
                                 />
                             </TouchableOpacity>
                         </View>
                     ))}
                 </ScrollView>
+
                 <View style={styles.inputContainer}>
                     <View style={styles.addIconContainer}>
                         <Gradient
@@ -175,7 +174,6 @@ const styles = StyleSheet.create({
     notchContainer: {
         flexShrink: 1
     },
-    editIcon: {},
     inputContainer: {
         flexDirection: 'row',
         alignItems: 'center',

--- a/packages/app/src/components/challenges/OutcomeCard.tsx
+++ b/packages/app/src/components/challenges/OutcomeCard.tsx
@@ -22,6 +22,7 @@ export const OutcomeCard = ({ type, form, setForm }: Props): ReactElement => {
     const [textValue, setTextValue] = useState('');
     const [listHeight, setListHeight] = useState(0);
     const [warningText, setWarningText] = useState('');
+    const [atListBottom, setAtListBottom] = useState(true);
     const scrollViewRef = useRef<ScrollView>(null);
     const positive = type === 'positiveOptions';
 
@@ -69,13 +70,31 @@ export const OutcomeCard = ({ type, form, setForm }: Props): ReactElement => {
                     ref={scrollViewRef}
                     style={styles.outcomeContainer}
                     showsVerticalScrollIndicator={false}
+                    scrollEventThrottle={200}
+                    onScroll={({
+                        nativeEvent: {
+                            contentOffset,
+                            layoutMeasurement,
+                            contentSize
+                        }
+                    }) => {
+                        const offset = contentOffset.y;
+                        const containerHeight = layoutMeasurement.height;
+                        const contentHeight = contentSize.height;
+
+                        if (contentHeight - offset <= containerHeight) {
+                            setAtListBottom(true);
+                        } else {
+                            setAtListBottom(false);
+                        }
+                    }}
                     contentContainerStyle={{
                         paddingTop: form[type].length > 0 ? '4%' : 0,
                         paddingBottom: form[type].length > 0 ? '2%' : 0,
                         paddingHorizontal: '4%'
                     }}
                     onContentSizeChange={(_, height) => {
-                        if (height > listHeight) {
+                        if (height > listHeight || atListBottom) {
                             scrollViewRef.current?.scrollToEnd({
                                 animated: true
                             });

--- a/packages/app/src/components/challenges/OutcomeCard.tsx
+++ b/packages/app/src/components/challenges/OutcomeCard.tsx
@@ -1,0 +1,203 @@
+import React, { ReactElement, useRef, useState } from 'react';
+import {
+    Text,
+    View,
+    StyleSheet,
+    TextInput,
+    TouchableOpacity,
+    KeyboardAvoidingView,
+    Platform
+} from 'react-native';
+import { Card, colors, Notch, sizes, Title } from '../UI';
+import { FormType } from './CreateChallengeScreen';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { ScrollView } from 'react-native-gesture-handler';
+
+type Props = {};
+
+export const OutcomeCard = ({ type, form, setForm }: any): ReactElement => {
+    const [textValue, setTextValue] = useState('');
+    const [listHeight, setListHeight] = useState(0);
+    const [warningText, setWarningText] = useState('');
+    const scrollViewRef = useRef(null);
+    const positive = type === 'positiveOptions';
+
+    const addOption = (type: string) => {
+        const duplicate =
+            form.positiveOptions.some(
+                (option: string) =>
+                    option.toLowerCase() === textValue.toLowerCase().trim()
+            ) ||
+            form.negativeOptions.some(
+                (option: string) =>
+                    option.toLowerCase() === textValue.toLowerCase().trim()
+            );
+
+        if (!duplicate && textValue.length > 2) {
+            setForm((prevState: FormType) => ({
+                ...prevState,
+                [type]: [...prevState[type], textValue]
+            }));
+
+            setWarningText('');
+            setTextValue('');
+        } else if (!duplicate && textValue.length <= 2) {
+            setWarningText('Enter at least 3 characters');
+        } else {
+            setWarningText('All outcomes must be unique');
+        }
+    };
+
+    const removeOption = (type: string, option: string) => {
+        setForm((prevState: FormType) => ({
+            ...prevState,
+            [type]: prevState[type].filter((item: string) => item !== option)
+        }));
+    };
+
+    return (
+        <>
+            <Title style={styles.title}>
+                Add {positive ? 'positive' : 'negative'} outcomes
+            </Title>
+            <Card style={styles.card} noPadding>
+                <ScrollView
+                    style={styles.outcomeContainer}
+                    showsVerticalScrollIndicator={false}
+                    contentContainerStyle={{
+                        paddingTop: form[type].length > 0 ? '4%' : 0,
+                        paddingBottom: form[type].length > 0 ? '2%' : 0,
+                        paddingHorizontal: '4%'
+                    }}
+                    onContentSizeChange={(_, height) => {
+                        if (height > listHeight) {
+                            scrollViewRef.current.scrollToEnd({
+                                animated: true
+                            });
+                        }
+                        setListHeight(height);
+                    }}
+                    ref={scrollViewRef}
+                >
+                    {form[type].map((option) => (
+                        <View style={styles.outcome}>
+                            <View style={styles.notchContainer}>
+                                <Notch
+                                    title={option}
+                                    pink={positive}
+                                    style={{
+                                        paddingHorizontal: 6
+                                    }}
+                                />
+                            </View>
+                            <TouchableOpacity
+                                onPress={() => removeOption(type, option)}
+                            >
+                                <Icon
+                                    name="close-thick"
+                                    size={22}
+                                    color={colors.pink}
+                                    style={styles.editIcon}
+                                />
+                            </TouchableOpacity>
+                        </View>
+                    ))}
+                </ScrollView>
+                <View style={styles.inputContainer}>
+                    <TouchableOpacity
+                        style={[
+                            styles.addIconBg,
+                            {
+                                backgroundColor: positive
+                                    ? colors.pink
+                                    : colors.gray
+                            }
+                        ]}
+                        onPress={() => addOption(type)}
+                    >
+                        <Icon
+                            name="plus-thick"
+                            size={28}
+                            color="white"
+                            style={styles.addIcon}
+                        />
+                    </TouchableOpacity>
+                    <TextInput
+                        onChangeText={setTextValue}
+                        value={textValue}
+                        style={styles.input}
+                        placeholder={
+                            positive
+                                ? 'e.g. I beat my best record'
+                                : 'e.g. I don’t finish in time'
+                        }
+                        placeholderTextColor={colors.gray}
+                    />
+                </View>
+            </Card>
+
+            <View
+                style={[
+                    styles.warning,
+                    { opacity: warningText.length > 0 ? 1 : 0 }
+                ]}
+            >
+                <Icon name="alert-circle-outline" size={20} color="#555" />
+                <Text style={styles.warningText}>{warningText}</Text>
+            </View>
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    title: {
+        marginBottom: '2%'
+    },
+    card: {
+        marginBottom: '2%'
+    },
+    outcomeContainer: {
+        maxHeight: sizes.windowH * 0.15
+    },
+    outcome: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginBottom: '3%'
+    },
+    notchContainer: {
+        flexShrink: 1
+    },
+    editIcon: {},
+    inputContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: '4%',
+        paddingVertical: '2%'
+    },
+    addIconBg: {
+        backgroundColor: colors.pink,
+        padding: 2,
+        borderRadius: 100,
+        marginRight: '4%'
+    },
+    addIcon: {},
+    input: {
+        flex: 1,
+        borderBottomColor: colors.gray,
+        borderBottomWidth: 1,
+        fontSize: 16,
+        paddingTop: 0,
+        paddingBottom: 2,
+        color: colors.grayDark
+    },
+    warning: {
+        marginBottom: '3%',
+        flexDirection: 'row',
+        alignItems: 'center'
+    },
+    warningText: {
+        color: '#555',
+        fontSize: 16,
+        marginLeft: 4
+    }
+});

--- a/packages/app/src/components/challenges/OutcomeCard.tsx
+++ b/packages/app/src/components/challenges/OutcomeCard.tsx
@@ -13,18 +13,22 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { ScrollView } from 'react-native-gesture-handler';
 
 type Props = {
-    type: 'positiveOptions' | 'negativeOptions';
+    positive: boolean;
     form: FormType;
     setForm: (form: FormType | ((prevState: FormType) => FormType)) => void;
 };
 
-export const OutcomeCard = ({ type, form, setForm }: Props): ReactElement => {
+export const OutcomeCard = ({
+    positive,
+    form,
+    setForm
+}: Props): ReactElement => {
     const [textValue, setTextValue] = useState('');
     const [listHeight, setListHeight] = useState(0);
     const [warningText, setWarningText] = useState('');
     const [atListBottom, setAtListBottom] = useState(true);
     const scrollViewRef = useRef<ScrollView>(null);
-    const positive = type === 'positiveOptions';
+    const type = positive ? 'positiveOptions' : 'negativeOptions';
 
     const addOption = (type: string) => {
         const duplicate =

--- a/packages/app/src/components/challenges/Outcomes.tsx
+++ b/packages/app/src/components/challenges/Outcomes.tsx
@@ -22,17 +22,9 @@ export const Outcomes = ({ form, setForm }: Props): ReactElement => {
                 but you must have at least one of each.
             </Text>
 
-            <OutcomeCard
-                type={'positiveOptions'}
-                form={form}
-                setForm={setForm}
-            />
+            <OutcomeCard positive form={form} setForm={setForm} />
 
-            <OutcomeCard
-                type={'negativeOptions'}
-                form={form}
-                setForm={setForm}
-            />
+            <OutcomeCard form={form} setForm={setForm} />
         </KeyboardAvoidingView>
     );
 };

--- a/packages/app/src/components/challenges/Outcomes.tsx
+++ b/packages/app/src/components/challenges/Outcomes.tsx
@@ -1,22 +1,26 @@
 import React, { ReactElement } from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, StyleSheet, KeyboardAvoidingView } from 'react-native';
 import { Title } from '../UI';
 import { FormType } from './CreateChallengeScreen';
 import { OutcomeCard } from './OutcomeCard';
 
 type Props = {
     form: FormType;
-    setForm: (fn: (f: FormType) => void) => void;
+    setForm: (form: FormType | ((prevState: FormType) => FormType)) => void;
 };
 
 /*
- * keyboard avoiding view
- * remove form placeholders
- */
+
+when list is scrolled to bottom and one above is deleted, move the list down
+
+*/
 
 export const Outcomes = ({ form, setForm }: Props): ReactElement => {
     return (
-        <View>
+        <KeyboardAvoidingView
+            behavior={'position'}
+            keyboardVerticalOffset={120}
+        >
             <Title style={styles.title}>Outcomes</Title>
             <Text style={styles.description}>
                 Describe what success and failure look like on this challenge.
@@ -35,7 +39,7 @@ export const Outcomes = ({ form, setForm }: Props): ReactElement => {
                 form={form}
                 setForm={setForm}
             />
-        </View>
+        </KeyboardAvoidingView>
     );
 };
 

--- a/packages/app/src/components/challenges/Outcomes.tsx
+++ b/packages/app/src/components/challenges/Outcomes.tsx
@@ -1,232 +1,53 @@
-import React, { ReactElement, useState } from 'react';
-import {
-    Text,
-    View,
-    StyleSheet,
-    TextInput,
-    TouchableOpacity,
-    KeyboardAvoidingView,
-    Platform
-} from 'react-native';
-import { Button, colors } from '../UI';
+import React, { ReactElement } from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+import { Title } from '../UI';
 import { FormType } from './CreateChallengeScreen';
-import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { OutcomeCard } from './OutcomeCard';
 
 type Props = {
-    index: number;
-    setIndex: (n: number) => void;
-    form: any;
+    form: FormType;
     setForm: (fn: any) => void;
-    type: 'positive' | 'negative';
 };
 
-export const Outcomes = ({
-    index,
-    setIndex,
-    form,
-    setForm,
-    type
-}: Props): ReactElement => {
-    const [value, setValue] = useState('');
-    const [duplicateWarn, setDuplicateWarn] = useState(false);
-    const formType =
-        type === 'positive' ? 'positiveOptions' : 'negativeOptions';
+/*
+ * keyboard avoiding view
+ * gradient
+ * prop types
+ * remove form placeholders
+ */
 
-    const handlePress = (direction?: string) => {
-        setValue('');
-        setDuplicateWarn(false);
-
-        if (direction === 'next') {
-            setIndex(++index);
-        } else {
-            setIndex(--index);
-        }
-    };
-
-    const addOption = () => {
-        const duplicate =
-            form.positiveOptions.some(
-                (option: string) =>
-                    option.toLowerCase() === value.toLowerCase().trim()
-            ) ||
-            form.negativeOptions.some(
-                (option: string) =>
-                    option.toLowerCase() === value.toLowerCase().trim()
-            );
-
-        if (!duplicate) {
-            setForm((prevState: FormType) => ({
-                ...prevState,
-                [formType]: [...prevState[formType], value.trim()]
-            }));
-            setValue('');
-            setDuplicateWarn(false);
-        } else {
-            setDuplicateWarn(true);
-        }
-    };
-
-    const removeOption = (option: string) => {
-        setForm((prevState: FormType) => ({
-            ...prevState,
-            [formType]: prevState[formType].filter((item) => item !== option)
-        }));
-    };
-
+export const Outcomes = ({ form, setForm }: Props): ReactElement => {
     return (
-        <View style={styles.container}>
-            <View>
-                <Text style={styles.description}>
-                    This will be a description about outcomes
-                </Text>
+        <View>
+            <Title style={styles.title}>Outcomes</Title>
+            <Text style={styles.description}>
+                Describe what success and failure look like on this challenge.
+                You can add as many types of success and failure as you want,
+                but you must have at least one of each.
+            </Text>
 
-                <KeyboardAvoidingView
-                    behavior={Platform.OS === 'ios' ? 'position' : 'padding'}
-                    keyboardVerticalOffset={96}
-                >
-                    <View style={styles.infoContainer}>
-                        <Text style={styles.title}>{type} Outcomes</Text>
-                        <View style={styles.card}>
-                            {form[formType].map((option: string) => (
-                                <View style={styles.outcome} key={option}>
-                                    <Icon
-                                        name="circle"
-                                        size={32}
-                                        color={
-                                            type === 'positive'
-                                                ? colors.green
-                                                : colors.pink
-                                        }
-                                    />
-                                    <Text style={styles.outcomeText}>
-                                        {option}
-                                    </Text>
+            <OutcomeCard
+                type={'positiveOptions'}
+                form={form}
+                setForm={setForm}
+            />
 
-                                    <TouchableOpacity
-                                        style={styles.removeOutcome}
-                                        onPress={() => removeOption(option)}
-                                    >
-                                        <Icon
-                                            name="close"
-                                            size={24}
-                                            color="#666"
-                                        />
-                                    </TouchableOpacity>
-                                </View>
-                            ))}
-
-                            <View style={styles.inputContainer}>
-                                <TouchableOpacity
-                                    style={styles.addOutcome}
-                                    onPress={addOption}
-                                    disabled={value.trim().length < 3}
-                                >
-                                    <Icon
-                                        name="plus"
-                                        size={32}
-                                        color="black"
-                                        style={{
-                                            opacity:
-                                                value.trim().length < 3
-                                                    ? 0.4
-                                                    : 1
-                                        }}
-                                    />
-                                </TouchableOpacity>
-
-                                <TextInput
-                                    onChangeText={setValue}
-                                    value={value}
-                                    style={styles.input}
-                                    placeholder={`Add ${type} outcome`}
-                                    placeholderTextColor="#333"
-                                />
-                            </View>
-
-                            <Text
-                                style={[
-                                    styles.warn,
-                                    { opacity: duplicateWarn ? 1 : 0 }
-                                ]}
-                            >
-                                Options must be unique.
-                            </Text>
-                        </View>
-                    </View>
-                </KeyboardAvoidingView>
-            </View>
-            <View style={styles.buttonContainer}>
-                <Button onPress={() => handlePress()} title="Back" small />
-                <Button
-                    onPress={() => handlePress('next')}
-                    title="Next"
-                    disabled={form[formType].length < 1}
-                    small
-                />
-            </View>
+            <OutcomeCard
+                type={'negativeOptions'}
+                form={form}
+                setForm={setForm}
+            />
         </View>
     );
 };
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: 'space-between'
-    },
-    infoContainer: {
-        marginTop: 36
+    title: {
+        marginBottom: '2%'
     },
     description: {
-        fontWeight: 'bold',
-        textAlign: 'center',
-        marginBottom: 40
-    },
-    title: {
-        fontSize: 24,
-        marginBottom: 40,
-        fontWeight: 'bold',
-        textTransform: 'uppercase'
-    },
-    card: {
-        backgroundColor: 'rgba(255,255,255,.5)',
-        borderRadius: 10,
-        paddingHorizontal: 16,
-        paddingVertical: 24
-    },
-    outcome: {
-        flexDirection: 'row',
-        marginBottom: 16,
-        alignItems: 'center'
-    },
-    outcomeText: {
-        borderBottomColor: 'black',
-        borderBottomWidth: 1,
-        flex: 1,
+        color: '#302449',
         fontSize: 16,
-        paddingHorizontal: 16
-    },
-    removeOutcome: {},
-    inputContainer: {
-        flexDirection: 'row',
-        marginTop: 16
-    },
-    input: {
-        borderBottomColor: 'black',
-        borderBottomWidth: 1,
-        flex: 1,
-        fontSize: 16,
-        paddingBottom: 4
-    },
-    addOutcome: {
-        marginRight: 16
-    },
-    warn: {
-        textAlign: 'center',
-        marginTop: 12,
-        color: '#333'
-    },
-    buttonContainer: {
-        flexDirection: 'row',
-        justifyContent: 'space-between'
+        marginBottom: '3%'
     }
 });

--- a/packages/app/src/components/challenges/Outcomes.tsx
+++ b/packages/app/src/components/challenges/Outcomes.tsx
@@ -9,12 +9,6 @@ type Props = {
     setForm: (form: FormType | ((prevState: FormType) => FormType)) => void;
 };
 
-/*
-
-when list is scrolled to bottom and one above is deleted, move the list down
-
-*/
-
 export const Outcomes = ({ form, setForm }: Props): ReactElement => {
     return (
         <KeyboardAvoidingView

--- a/packages/app/src/components/challenges/Outcomes.tsx
+++ b/packages/app/src/components/challenges/Outcomes.tsx
@@ -6,13 +6,11 @@ import { OutcomeCard } from './OutcomeCard';
 
 type Props = {
     form: FormType;
-    setForm: (fn: any) => void;
+    setForm: (fn: (f: FormType) => void) => void;
 };
 
 /*
  * keyboard avoiding view
- * gradient
- * prop types
  * remove form placeholders
  */
 

--- a/packages/app/src/components/challenges/StartChallenge.tsx
+++ b/packages/app/src/components/challenges/StartChallenge.tsx
@@ -7,7 +7,6 @@ import {
     Platform
 } from 'react-native';
 import { colors, sizes, Title } from '../UI';
-import { Buttons } from './Buttons';
 import { FormType } from './CreateChallengeScreen';
 import { ImageUpload } from './ImageUpload';
 
@@ -16,12 +15,7 @@ type Props = {
     setForm: (fn: any) => void;
 };
 
-export const StartChallenge = ({
-    form,
-    setForm,
-    index,
-    setIndex
-}: Props): ReactElement => {
+export const StartChallenge = ({ form, setForm }: Props): ReactElement => {
     const handleOnChange = (type: string, value: string) => {
         setForm((prevState: FormType) => ({
             ...prevState,

--- a/packages/app/src/components/challenges/StartChallenge.tsx
+++ b/packages/app/src/components/challenges/StartChallenge.tsx
@@ -7,6 +7,7 @@ import {
     Platform
 } from 'react-native';
 import { colors, sizes, Title } from '../UI';
+import { Buttons } from './Buttons';
 import { FormType } from './CreateChallengeScreen';
 import { ImageUpload } from './ImageUpload';
 
@@ -15,7 +16,12 @@ type Props = {
     setForm: (fn: any) => void;
 };
 
-export const StartChallenge = ({ form, setForm }: Props): ReactElement => {
+export const StartChallenge = ({
+    form,
+    setForm,
+    index,
+    setIndex
+}: Props): ReactElement => {
     const handleOnChange = (type: string, value: string) => {
         setForm((prevState: FormType) => ({
             ...prevState,


### PR DESCRIPTION
Adds back and next buttons to new challenge screen. Adds "navigate back to profile screen" button. Stops maintabs swipe when new challenge flow is open. Closes #350 

![new-challenge-buttons](https://user-images.githubusercontent.com/19338130/126355760-7dfd2f43-131d-40da-b4c7-9f8038fe8ba3.gif)
